### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: ci


### PR DESCRIPTION
Potential fix for [https://github.com/Adriel-M/adriel.dev/security/code-scanning/1](https://github.com/Adriel-M/adriel.dev/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily interacts with repository contents (e.g., checking out code), the minimal required permission is `contents: read`. This ensures the workflow adheres to the principle of least privilege while maintaining functionality.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. Alternatively, it can be added specifically to the `ci` job if future jobs might require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
