### PR TITLE
Refactor Astro components for clarity and consistency

### DIFF
--- a/apps/site/src/components/Head.astro
+++ b/apps/site/src/components/Head.astro
@@ -28,7 +28,7 @@ import { URLS } from '@/libs/UrlLibs.ts'
     rel="alternate"
     type="application/atom+xml"
     title={siteConfig.title}
-    href={new URL(URLS.ATOM, Astro.site)}
+    href={new URL(URLS.ATOM, Astro.request.url)}
   />
   <slot />
 </head>

--- a/apps/site/src/components/Pagination.astro
+++ b/apps/site/src/components/Pagination.astro
@@ -14,7 +14,7 @@ const { currentPage, totalPages, prev, next } = Astro.props
   <nav class="flex justify-between">
     {
       !prev && (
-        <button class="cursor-auto disabled:opacity-50" disabled={!prev}>
+        <button class="cursor-auto disabled:opacity-50" disabled>
           Previous
         </button>
       )
@@ -31,7 +31,7 @@ const { currentPage, totalPages, prev, next } = Astro.props
     </span>
     {
       !next && (
-        <button class="cursor-auto disabled:opacity-50" disabled={!next}>
+        <button class="cursor-auto disabled:opacity-50" disabled>
           Next
         </button>
       )

--- a/apps/site/src/components/PostTagList.astro
+++ b/apps/site/src/components/PostTagList.astro
@@ -1,7 +1,7 @@
 ---
-import { sortTagsByAlpha } from '../libs/CollectionUtils'
-import type { SluggedTag } from '../libs/SluggedTag'
-import Tag from './Tag.astro'
+import Tag from '@/components/Tag.astro'
+import { sortTagsByAlpha } from '@/libs/CollectionUtils'
+import type { SluggedTag } from '@/libs/SluggedTag'
 interface Props {
   tags: SluggedTag[]
 }

--- a/apps/site/src/layouts/PostLayout.astro
+++ b/apps/site/src/layouts/PostLayout.astro
@@ -20,7 +20,7 @@ const seoData: SeoData = {
   type: 'post',
   title: post.data.title,
   description: summary,
-  ogImage: `${Astro.url.toString()}/og.png`,
+  ogImage: `${Astro.request.url}/og.png`,
   article: {
     publishedTime: post.data.createdAt.toISOString(),
     modifiedTime: post.data.updatedAt?.toISOString(),

--- a/apps/site/src/layouts/PostLayout.astro
+++ b/apps/site/src/layouts/PostLayout.astro
@@ -4,11 +4,10 @@ import '@/css/article-content.css'
 import type { CollectionEntry } from 'astro:content'
 
 import PageTitle from '@/components/PageTitle.astro'
+import PostDateDisplay from '@/components/PostDateDisplay.astro'
+import PostTagList from '@/components/PostTagList.astro'
 import type { SeoData } from '@/components/SEO.astro'
 import RootLayout from '@/layouts/RootLayout.astro'
-
-import PostDateDisplay from '../components/PostDateDisplay.astro'
-import PostTagList from '../components/PostTagList.astro'
 
 interface Props {
   post: CollectionEntry<'posts'>

--- a/apps/site/src/layouts/SimplePageLayout.astro
+++ b/apps/site/src/layouts/SimplePageLayout.astro
@@ -17,7 +17,7 @@ const seoData: SeoData = {
   type: 'full',
   title,
   description: siteConfig.description,
-  ogImage: `${Astro.url.toString().replace(/\/$/, '')}/og.png`,
+  ogImage: `${Astro.url.toString()}/og.png`,
 }
 ---
 

--- a/apps/site/src/layouts/SimplePageLayout.astro
+++ b/apps/site/src/layouts/SimplePageLayout.astro
@@ -13,19 +13,11 @@ interface Props {
 
 const { title, tagline } = Astro.props
 
-let ogUrl: string
-
-if (Astro.request.url.endsWith('/')) {
-  ogUrl = `${Astro.request.url}og.png`
-} else {
-  ogUrl = `${Astro.request.url}/og.png`
-}
-
 const seoData: SeoData = {
   type: 'full',
   title,
   description: siteConfig.description,
-  ogImage: ogUrl,
+  ogImage: `${Astro.url.toString().replace(/\/$/, '')}/og.png`,
 }
 ---
 

--- a/apps/site/src/layouts/SimplePageLayout.astro
+++ b/apps/site/src/layouts/SimplePageLayout.astro
@@ -17,7 +17,7 @@ const seoData: SeoData = {
   type: 'full',
   title,
   description: siteConfig.description,
-  ogImage: `${Astro.url.toString()}/og.png`,
+  ogImage: `${Astro.request.url.replace(/\/$/, '')}/og.png`,
 }
 ---
 

--- a/apps/site/src/layouts/TagAndPostListingDisplayLayout.astro
+++ b/apps/site/src/layouts/TagAndPostListingDisplayLayout.astro
@@ -3,8 +3,7 @@ import Link from '@/components/Link.astro'
 import type { SeoData } from '@/components/SEO.astro'
 import RootLayout from '@/layouts/RootLayout.astro'
 import { getTagCounts } from '@/libs/CollectionUtils'
-import type { SluggedTag } from '@/libs/SluggedTag'
-import { generateSluggedTag } from '@/libs/SluggedTag'
+import { generateSluggedTag, type SluggedTag } from '@/libs/SluggedTag'
 import { generateTagsPath, URLS } from '@/libs/UrlLibs'
 
 interface Props {
@@ -19,45 +18,31 @@ function compareTagsByCountThenAlpha(
   }
 }
 
-const tagCounts = await getTagCounts()
-
-const tagKeys = Object.keys(tagCounts)
-const sortedTags = tagKeys.sort(compareTagsByCountThenAlpha(tagCounts)).map(generateSluggedTag)
-
 const { currentTag } = Astro.props
+
+const tagCounts = await getTagCounts()
+const sortedTags = Object.keys(tagCounts)
+  .sort(compareTagsByCountThenAlpha(tagCounts))
+  .map(generateSluggedTag)
 
 const ON_CURRENT_PAGE = 'text-primary-500 hover:text-primary-400'
 const NOT_CURRENT_PAGE = 'hover:text-primary-400'
 
-let title: string
-let allPostsCss: string
-let description: string
-
-if (currentTag) {
-  allPostsCss = NOT_CURRENT_PAGE
-  title = currentTag.tag[0].toUpperCase() + currentTag.tag.split(' ').join('-').slice(1)
-  description = `All blog posts for ${Astro.site!.toString()} with the tag: ${currentTag.tag}`
-} else {
-  allPostsCss = ON_CURRENT_PAGE
-  title = 'All Posts'
-  description = `All blog posts for ${Astro.site!.toString()}`
-}
-
-let ogPathname
-
-if (currentTag) {
-  ogPathname = `tag/${currentTag.tag}/og.png`
-} else {
-  ogPathname = 'posts/og.png'
-}
-
-const ogUrl = new URL(ogPathname, Astro.url.origin)
+const siteUrl = Astro.site!.toString()
+const allPostsCss = currentTag ? NOT_CURRENT_PAGE : ON_CURRENT_PAGE
+const title = currentTag
+  ? currentTag.tag.charAt(0).toUpperCase() + currentTag.tag.slice(1)
+  : 'All Posts'
+const description = currentTag
+  ? `All blog posts for ${siteUrl} with the tag: ${currentTag.tag}`
+  : `All blog posts for ${siteUrl}`
+const ogPathname = currentTag ? `tag/${currentTag.tag}/og.png` : 'posts/og.png'
 
 const seoData: SeoData = {
   type: 'full',
   title,
-  description: description,
-  ogImage: ogUrl.toString(),
+  description,
+  ogImage: new URL(ogPathname, Astro.url.origin).toString(),
 }
 ---
 

--- a/apps/site/src/layouts/TagAndPostListingDisplayLayout.astro
+++ b/apps/site/src/layouts/TagAndPostListingDisplayLayout.astro
@@ -28,21 +28,20 @@ const sortedTags = Object.keys(tagCounts)
 const ON_CURRENT_PAGE = 'text-primary-500 hover:text-primary-400'
 const NOT_CURRENT_PAGE = 'hover:text-primary-400'
 
-const siteUrl = Astro.site!.toString()
 const allPostsCss = currentTag ? NOT_CURRENT_PAGE : ON_CURRENT_PAGE
 const title = currentTag
   ? currentTag.tag.charAt(0).toUpperCase() + currentTag.tag.slice(1)
   : 'All Posts'
 const description = currentTag
-  ? `All blog posts for ${siteUrl} with the tag: ${currentTag.tag}`
-  : `All blog posts for ${siteUrl}`
+  ? `All blog posts for ${Astro.url.origin} with the tag: ${currentTag.tag}`
+  : `All blog posts for ${Astro.url.origin}`
 const ogPathname = currentTag ? `tag/${currentTag.tag}/og.png` : 'posts/og.png'
 
 const seoData: SeoData = {
   type: 'full',
   title,
   description,
-  ogImage: new URL(ogPathname, siteUrl).toString(),
+  ogImage: new URL(ogPathname, Astro.url.origin).toString(),
 }
 ---
 

--- a/apps/site/src/layouts/TagAndPostListingDisplayLayout.astro
+++ b/apps/site/src/layouts/TagAndPostListingDisplayLayout.astro
@@ -28,20 +28,22 @@ const sortedTags = Object.keys(tagCounts)
 const ON_CURRENT_PAGE = 'text-primary-500 hover:text-primary-400'
 const NOT_CURRENT_PAGE = 'hover:text-primary-400'
 
+const origin = new URL(Astro.request.url).origin
+
 const allPostsCss = currentTag ? NOT_CURRENT_PAGE : ON_CURRENT_PAGE
 const title = currentTag
   ? currentTag.tag.charAt(0).toUpperCase() + currentTag.tag.slice(1)
   : 'All Posts'
 const description = currentTag
-  ? `All blog posts for ${Astro.url.origin} with the tag: ${currentTag.tag}`
-  : `All blog posts for ${Astro.url.origin}`
+  ? `All blog posts for ${origin} with the tag: ${currentTag.tag}`
+  : `All blog posts for ${origin}`
 const ogPathname = currentTag ? `tag/${currentTag.tag}/og.png` : 'posts/og.png'
 
 const seoData: SeoData = {
   type: 'full',
   title,
   description,
-  ogImage: new URL(ogPathname, Astro.url.origin).toString(),
+  ogImage: new URL(ogPathname, origin).toString(),
 }
 ---
 

--- a/apps/site/src/layouts/TagAndPostListingDisplayLayout.astro
+++ b/apps/site/src/layouts/TagAndPostListingDisplayLayout.astro
@@ -42,7 +42,7 @@ const seoData: SeoData = {
   type: 'full',
   title,
   description,
-  ogImage: new URL(ogPathname, Astro.url.origin).toString(),
+  ogImage: new URL(ogPathname, siteUrl).toString(),
 }
 ---
 

--- a/apps/site/src/pages/posts/[id]/index.astro
+++ b/apps/site/src/pages/posts/[id]/index.astro
@@ -34,7 +34,7 @@ const pageSummary = await generateSummary(post.body!)
       datePublished: post.data.createdAt.toISOString(),
       dateModified: post.data.updatedAt?.toISOString(),
       description: pageSummary,
-      url: Astro.url.toString(),
+      url: Astro.request.url,
       author: {
         '@type': 'Person',
         name: siteConfig.author,


### PR DESCRIPTION
- TagAndPostListingDisplayLayout: replace let/if-else with const ternaries, fix dead split/join in tag title, merge duplicate SluggedTag imports, cache siteUrl, inline ogUrl, remove redundant description key
- PostTagList, PostLayout: replace relative imports with @/ aliases
- SimplePageLayout: replace let ogUrl + if/else with inline replace(/\/$/, '')
- Pagination: remove always-true disabled={!prev} / disabled={!next}