### PR TITLE
Fix astro check type errors

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -36,8 +36,11 @@
     "@playform/compress": "0.2.3",
     "@tailwindcss/typography": "0.5.19",
     "@tailwindcss/vite": "4.2.4",
+    "@types/hast": "^3.0.4",
+    "@types/mdast": "^4.0.4",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@types/unist": "^3.0.3",
     "@vercel/og": "0.11.1",
     "astro": "6.2.2",
     "astro-robots-txt": "1.0.0",
@@ -71,6 +74,7 @@
     "tailwindcss": "4.2.4",
     "title-case": "4.3.2",
     "unist-util-visit": "5.1.0",
+    "vfile": "^6.0.3",
     "vite-plugin-svgr": "5.2.0",
     "vitest": "4.1.5"
   }

--- a/packages/esm-wrapper/package.json
+++ b/packages/esm-wrapper/package.json
@@ -23,6 +23,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,12 +102,21 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.2.4
         version: 4.2.4(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
       '@vercel/og':
         specifier: 0.11.1
         version: 0.11.1
@@ -207,6 +216,9 @@ importers:
       unist-util-visit:
         specifier: 5.1.0
         version: 5.1.0
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
       vite-plugin-svgr:
         specifier: 5.2.0
         version: 5.2.0(rollup@4.60.3)(typescript@6.0.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))


### PR DESCRIPTION
## Summary

- Add `@types/unist`, `@types/hast`, `@types/mdast`, and `vfile` as explicit `devDependencies` in `apps/site` — they were being used in plugin/test files but only resolved as transitive deps, which `astro check` couldn't see
- Add `"types": "./dist/index.d.ts"` to `esm-wrapper`'s `exports` map so `@adrieldev/esm-wrapper` resolves its TypeScript declarations properly

## Test plan

- [ ] `pnpm check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)