### PR TITLE
Replace deprecated z import from astro:content with astro/zod

### DIFF
--- a/apps/site/src/content/definitions/posts.ts
+++ b/apps/site/src/content/definitions/posts.ts
@@ -1,5 +1,6 @@
 import { glob } from 'astro/loaders'
-import { defineCollection, z } from 'astro:content'
+import { z } from 'astro/zod'
+import { defineCollection } from 'astro:content'
 
 export default defineCollection({
   loader: glob({ pattern: '**/*.mdx', base: './src/content/posts' }),


### PR DESCRIPTION
## Summary
- Moves `z` import from the deprecated `astro:content` export to `astro/zod`

## Test plan
- [ ] `pnpm check` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)