### PR TITLE
Move @types/react and @types/react-dom to peerDependencies in esm-wra…

### DIFF
--- a/packages/esm-wrapper/package.json
+++ b/packages/esm-wrapper/package.json
@@ -12,11 +12,11 @@
   },
   "devDependencies": {
     "@docsearch/react": "4.6.3",
-    "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
     "pkgroll": "2.27.0"
   },
   "peerDependencies": {
+    "@types/react": ">=18",
+    "@types/react-dom": ">=18",
     "react": ">=18",
     "react-dom": ">=18",
     "typescript": "^5 || ^6.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,12 @@ importers:
 
   packages/esm-wrapper:
     dependencies:
+      '@types/react':
+        specifier: '>=18'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: '>=18'
+        version: 19.2.3(@types/react@19.2.14)
       react:
         specifier: '>=18'
         version: 19.2.5
@@ -287,12 +293,6 @@ importers:
       '@docsearch/react':
         specifier: 4.6.3
         version: 4.6.3(@algolia/client-search@5.52.1)(@types/react@19.2.14)(algoliasearch@5.52.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)
-      '@types/react':
-        specifier: 19.2.14
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.14)
       pkgroll:
         specifier: 2.27.0
         version: 2.27.0(typescript@6.0.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))


### PR DESCRIPTION
…pper

Resolves pkgroll warning about bundled @types/react when react is externalized.