### PR TITLE
Simplify component markup and fix import path

### DIFF
--- a/apps/site/src/components/PostDateDisplay.astro
+++ b/apps/site/src/components/PostDateDisplay.astro
@@ -1,7 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content'
 
-import { formatDate } from '../libs/DateUtils'
+import { formatDate } from '@/libs/DateUtils'
 
 interface Props {
   post: CollectionEntry<'posts'>

--- a/apps/site/src/components/ScrollTop.astro
+++ b/apps/site/src/components/ScrollTop.astro
@@ -2,27 +2,23 @@
 import ArrowUp from '@/assets/remix-icons/arrow-up-line.svg'
 ---
 
-<div id="scroll-top" class="fixed right-8 bottom-8 hidden flex-col gap-3 md:hidden">
-  <button
-    aria-label="Scroll To Top"
-    class="rounded-full bg-gray-200 p-2 text-gray-500 transition-all hover:bg-gray-300"
-  >
-    <ArrowUp class="size-6" />
-  </button>
-</div>
+<button
+  id="scroll-top"
+  aria-label="Scroll To Top"
+  class="fixed right-8 bottom-8 hidden rounded-full bg-gray-200 p-2 text-gray-500 transition-all hover:bg-gray-300"
+>
+  <ArrowUp class="size-6" />
+</button>
 
 <script>
   import { throttle } from '@/libs/FunctionUtils.ts'
 
-  const el = document.getElementById('scroll-top')!
-  const btn = el.querySelector('button')!
+  const btn = document.getElementById('scroll-top')!
 
   const update = () => {
-    const visible = window.scrollY > 50
-    el.classList.toggle('md:hidden', !visible)
-    el.classList.toggle('md:flex', visible)
+    btn.classList.toggle('md:block', window.scrollY > 50)
   }
   update()
-  window.addEventListener('scroll', throttle(update))
+  window.addEventListener('scroll', throttle(update), { passive: true })
   btn.addEventListener('click', () => window.scrollTo({ top: 0 }))
 </script>

--- a/apps/site/src/layouts/PostLayout.astro
+++ b/apps/site/src/layouts/PostLayout.astro
@@ -32,21 +32,15 @@ const seoData: SeoData = {
     <slot name="jsonLd" />
   </Fragment>
   <article>
-    <div>
-      <header>
-        <div class="space-y-1 border-b border-gray-200 pb-10 text-center">
-          <PageTitle title={post.data.title} />
-          <PostDateDisplay post={post} />
-        </div>
-      </header>
-      {Astro.slots.has('toc') && <slot name="toc" />}
-      <div class="grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 xl:divide-y-0">
-        <div class="divide-y divide-gray-200 xl:col-span-3 xl:row-span-2 xl:pb-0">
-          <div id="article-body" class="prose max-w-none pt-10 pb-4">
-            <slot />
-          </div>
-        </div>
+    <header>
+      <div class="space-y-1 border-b border-gray-200 pb-10 text-center">
+        <PageTitle title={post.data.title} />
+        <PostDateDisplay post={post} />
       </div>
+    </header>
+    {Astro.slots.has('toc') && <slot name="toc" />}
+    <div class="prose max-w-none pt-10 pb-8 xl:pb-4">
+      <slot />
     </div>
   </article>
 </RootLayout>


### PR DESCRIPTION
- ScrollTop: drop wrapper div, remove dead Tailwind classes, attach scroll/click handlers directly to the button
- PostLayout: collapse three nested wrapper divs whose grid/divide classes had no effect, drop unreferenced article-body id
- PostDateDisplay: switch relative import to the @/ alias