### PR TITLE
Small cleanups across pages and plugins

### DIFF
--- a/apps/site/src/components/Gallery.astro
+++ b/apps/site/src/components/Gallery.astro
@@ -31,7 +31,7 @@ const optimizedImages: {
 const imageAlt = `Gallery Preview of ${description}`
 ---
 
-<image-gallery class="grid grid-cols-2 gap-4 md:grid-cols-2 lg:grid-cols-3">
+<image-gallery class="grid grid-cols-2 gap-4 lg:grid-cols-3">
   {
     optimizedImages.map(({ original, optimized }) => (
       <a

--- a/apps/site/src/pages/404.astro
+++ b/apps/site/src/pages/404.astro
@@ -12,9 +12,9 @@ const seoData: SeoData = {
 
 <RootLayout seoData={seoData}>
   <div
-    class="flex flex-col items-start justify-start md:mt-24 md:flex-row md:items-center md:justify-center md:space-x-6"
+    class="flex flex-col items-start md:mt-24 md:flex-row md:items-center md:justify-center md:space-x-6"
   >
-    <div class="space-x-2 pt-6 pb-8 md:space-y-5">
+    <div class="pt-6 pb-8">
       <h1
         class="border-gray-200 text-6xl leading-9 font-extrabold tracking-tight text-gray-900 md:border-r-2 md:px-6 md:text-8xl md:leading-14"
       >
@@ -22,13 +22,11 @@ const seoData: SeoData = {
       </h1>
     </div>
     <div class="max-w-md">
-      <p class="mb-4 text-xl leading-normal font-bold md:text-2xl">
-        Sorry we couldn&apos;t find this page.
-      </p>
-      <p class="mb-8">But dont worry, you can find plenty of other things on our homepage.</p>
+      <p class="mb-4 text-xl leading-normal font-bold md:text-2xl">This page doesn&apos;t exist.</p>
+      <p class="mb-8">Head back to the homepage to find something else.</p>
       <Link
         href={URLS.HOME}
-        class="inline rounded-lg border border-transparent bg-primary-600 px-4 py-2 text-sm leading-5 font-medium text-white shadow transition-colors duration-150 hover:bg-primary-400"
+        class="rounded-lg border border-transparent bg-primary-600 px-4 py-2 text-sm leading-5 font-medium text-white shadow transition-colors duration-150 hover:bg-primary-400"
       >
         Back to homepage
       </Link>

--- a/apps/site/src/pages/atom.xml.ts
+++ b/apps/site/src/pages/atom.xml.ts
@@ -51,9 +51,7 @@ export async function GET({ request }: { request: Request }) {
     copyright: copyrightNotice,
   })
 
-  for (const postAndSummary of postAndSummaries) {
-    const { post, summary } = postAndSummary
-
+  for (const { post, summary } of postAndSummaries) {
     feed.addItem({
       title: post.data.title,
       id: `${siteUrl}/posts/${post.id}`,

--- a/apps/site/src/plugins/rehype-hide-heading.ts
+++ b/apps/site/src/plugins/rehype-hide-heading.ts
@@ -9,8 +9,7 @@ function rehypeHideHeading() {
       if (!HEADING_TAGS.has(node.tagName)) return
       if (node.properties?.dataHidden === undefined) return
 
-      const classes = (node.properties?.className as string[] | undefined) ?? []
-      node.properties = node.properties ?? {}
+      const classes = (node.properties.className as string[] | undefined) ?? []
       node.properties.className = [...classes, 'hidden-heading']
     })
   }


### PR DESCRIPTION
- 404: reword body copy and drop dead space-x/space-y classes on a single-child wrapper, fix the missing apostrophe in "don't"
- rehype-hide-heading: drop redundant properties-existence guard since the early return above already proves properties is defined
- atom feed: destructure post/summary in the loop signature