### PR TITLE
Switch site accent color from indigo to blue

### DIFF
--- a/apps/site/src/components/Header.astro
+++ b/apps/site/src/components/Header.astro
@@ -10,7 +10,7 @@ import { URLS } from '@/libs/UrlLibs'
 <header class="flex items-center justify-between py-10">
   <div>
     <Link href={URLS.HOME} aria-label={siteConfig.title}>
-      <div class="flex items-center justify-between hover:text-primary-400">
+      <div class="flex items-center justify-between hover:text-primary-600">
         <div class="mr-5">
           <Logo />
         </div>
@@ -21,7 +21,7 @@ import { URLS } from '@/libs/UrlLibs'
   <div class="flex items-center space-x-4 leading-5 sm:space-x-6">
     {
       headerNavLinks.map((link) => (
-        <Link href={link.href} class="font-medium hover:text-primary-400">
+        <Link href={link.href} class="font-medium hover:text-primary-600">
           {link.title}
         </Link>
       ))

--- a/apps/site/src/components/SocialIcon.astro
+++ b/apps/site/src/components/SocialIcon.astro
@@ -22,5 +22,5 @@ const SocialSvg = components[kind]
 
 <Link href={href}>
   <span class="sr-only">{kind}</span>
-  <SocialSvg class="size-8 fill-current text-gray-700 hover:text-primary-400" />
+  <SocialSvg class="size-8 fill-current text-gray-700 hover:text-primary-600" />
 </Link>

--- a/apps/site/src/components/floating-toc/FloatingToc.astro
+++ b/apps/site/src/components/floating-toc/FloatingToc.astro
@@ -65,7 +65,7 @@ const entries = generateTocEntries(headings)
 
     const setActive = (slug: string | undefined) => {
       for (const link of links) {
-        link.classList.toggle('text-primary-500', link.dataset.tocSlug === slug)
+        link.classList.toggle('text-primary-600', link.dataset.tocSlug === slug)
       }
     }
 

--- a/apps/site/src/components/floating-toc/TocEntryList.astro
+++ b/apps/site/src/components/floating-toc/TocEntryList.astro
@@ -17,7 +17,7 @@ const borderCss = isNested ? 'pl-2 border-l-2 border-gray-200/25' : ''
       {entries.map((entry: TocEntry) => (
         <li class="list-inside list-disc">
           <a
-            class="no-underline hover:text-primary-400"
+            class="rounded px-1 no-underline hover:bg-primary-100"
             href={`#${entry.slug}`}
             data-toc-slug={entry.slug}
           >

--- a/apps/site/src/components/footer/Footer.astro
+++ b/apps/site/src/components/footer/Footer.astro
@@ -18,7 +18,7 @@ import { URLS } from '@/libs/UrlLibs.ts'
       <div>{` • `}</div>
       <div>Adriel Martinez</div>
       <div>{` • `}</div>
-      <Link href="/license" class="hover:text-primary-400"> CC BY 4.0 </Link>
+      <Link href="/license" class="hover:text-primary-600"> CC BY 4.0 </Link>
     </div>
   </div>
 </footer>

--- a/apps/site/src/css/article-content.css
+++ b/apps/site/src/css/article-content.css
@@ -19,7 +19,7 @@ article {
       color: var(--color-primary-600);
 
       &:hover {
-        color: var(--color-primary-400);
+        background-color: var(--color-primary-100);
       }
     }
 
@@ -79,7 +79,7 @@ article {
     transition: opacity 0.15s ease;
 
     &:hover {
-      color: var(--color-primary-400);
+      color: var(--color-primary-700);
     }
 
     svg {

--- a/apps/site/src/css/global.css
+++ b/apps/site/src/css/global.css
@@ -5,15 +5,15 @@
 
 @theme {
   --font-mono: 'JetBrains Mono', monospace;
-  --color-primary-50: var(--color-indigo-50);
-  --color-primary-100: var(--color-indigo-100);
-  --color-primary-200: var(--color-indigo-200);
-  --color-primary-300: var(--color-indigo-300);
-  --color-primary-400: var(--color-indigo-400);
-  --color-primary-500: var(--color-indigo-500);
-  --color-primary-600: var(--color-indigo-600);
-  --color-primary-700: var(--color-indigo-700);
-  --color-primary-800: var(--color-indigo-800);
-  --color-primary-900: var(--color-indigo-900);
-  --color-primary-950: var(--color-indigo-950);
+  --color-primary-50: var(--color-blue-50);
+  --color-primary-100: var(--color-blue-100);
+  --color-primary-200: var(--color-blue-200);
+  --color-primary-300: var(--color-blue-300);
+  --color-primary-400: var(--color-blue-400);
+  --color-primary-500: var(--color-blue-500);
+  --color-primary-600: var(--color-blue-600);
+  --color-primary-700: var(--color-blue-700);
+  --color-primary-800: var(--color-blue-800);
+  --color-primary-900: var(--color-blue-900);
+  --color-primary-950: var(--color-blue-950);
 }

--- a/apps/site/src/pages/404.astro
+++ b/apps/site/src/pages/404.astro
@@ -26,7 +26,7 @@ const seoData: SeoData = {
       <p class="mb-8">Head back to the homepage to find something else.</p>
       <Link
         href={URLS.HOME}
-        class="rounded-lg border border-transparent bg-primary-600 px-4 py-2 text-sm leading-5 font-medium text-white shadow transition-colors duration-150 hover:bg-primary-400"
+        class="rounded-lg border border-transparent bg-primary-600 px-4 py-2 text-sm leading-5 font-medium text-white shadow transition-colors duration-150 hover:bg-primary-700"
       >
         Back to homepage
       </Link>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -29,7 +29,7 @@ export const title = 'Thinking Emoji 🤔'
           <ul class="divide-y divide-gray-100">
             {postsByYear[year].map((post) => (
               <li class="flex items-center justify-between gap-8 py-2">
-                <Link href={generatePostPath(post)} class="text-gray-900 hover:text-primary-400">
+                <Link href={generatePostPath(post)} class="text-gray-900 hover:text-primary-600">
                   {post.data.title}
                 </Link>
                 <time


### PR DESCRIPTION
Remap the primary color scale to Tailwind's blue palette and move all interactive states to contrast-safe steps (WCAG AA on white). Blog post links and TOC entries now use a background tint on hover; the active TOC entry is distinguished by color.