### PR TITLE
Improve Lighthouse scores for LCP and contrast

### DIFF
--- a/apps/site/src/components/Logo.astro
+++ b/apps/site/src/components/Logo.astro
@@ -4,4 +4,10 @@ import { Image } from 'astro:assets'
 import LogoMin from '@/assets/logo.min.svg'
 ---
 
-<Image src={LogoMin} alt="logo" class="size-18 rounded-br-[37px]" loading="eager" />
+<Image
+  src={LogoMin}
+  alt="logo"
+  class="size-18 rounded-br-[37px]"
+  loading="eager"
+  fetchpriority="high"
+/>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -25,16 +25,16 @@ export const title = 'Thinking Emoji 🤔'
     {
       years.map((year) => (
         <section>
-          <h2 class="mb-3 text-sm font-semibold tracking-widest text-gray-400 uppercase">{year}</h2>
+          <h2 class="mb-3 text-sm font-semibold tracking-widest text-gray-500 uppercase">{year}</h2>
           <ul class="divide-y divide-gray-100">
             {postsByYear[year].map((post) => (
               <li class="flex items-center justify-between gap-8 py-2">
-                <Link href={generatePostPath(post)} class="text-gray-900 hover:text-primary-600">
+                <Link href={generatePostPath(post)} class="text-gray-700 hover:text-primary-600">
                   {post.data.title}
                 </Link>
                 <time
                   datetime={post.data.createdAt.toISOString()}
-                  class="shrink-0 text-sm text-gray-400 tabular-nums"
+                  class="shrink-0 text-sm text-gray-500 tabular-nums"
                 >
                   {formatShortDate(post.data.createdAt)}
                 </time>


### PR DESCRIPTION
- Add fetchpriority=high to LCP image (logo) for faster discovery
- Bump year headers and dates from text-gray-400 to text-gray-500 to meet WCAG AA contrast
- Pull post title links from text-gray-900 to text-gray-700 to preserve visual hierarchy