### PR TITLE
Defer DocSearch init to requestIdleCallback

### DIFF
--- a/apps/site/src/components/search/Search.astro
+++ b/apps/site/src/components/search/Search.astro
@@ -52,9 +52,8 @@ const onload = "this.media='all'; this.onload=null;"
   }
 
   class DocSearchContainer extends HTMLElement {
-    constructor() {
-      super()
-      window.addEventListener('DOMContentLoaded', async () => {
+    connectedCallback() {
+      const init = async () => {
         const { docsearch } = await import('@adrieldev/esm-wrapper')
 
         docsearch({
@@ -108,7 +107,13 @@ const onload = "this.media='all'; this.onload=null;"
             })
           },
         })
-      })
+      }
+
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(init)
+      } else {
+        setTimeout(init, 0)
+      }
     }
   }
 

--- a/apps/site/src/components/search/Search.astro
+++ b/apps/site/src/components/search/Search.astro
@@ -54,7 +54,12 @@ const onload = "this.media='all'; this.onload=null;"
   class DocSearchContainer extends HTMLElement {
     connectedCallback() {
       const init = async () => {
-        const { docsearch } = await import('@adrieldev/esm-wrapper')
+        // @vite-ignore prevents Vite from statically analyzing this import,
+        // which stops it from emitting <link rel="modulepreload"> tags for the
+        // esm-wrapper chunks (~175 KiB) in the page HTML. Without it, those
+        // chunks are fetched immediately on page load regardless of when this
+        // code actually runs.
+        const { docsearch } = await import(/* @vite-ignore */ '@adrieldev/esm-wrapper')
 
         docsearch({
           container: this,


### PR DESCRIPTION
Switches DocSearchContainer from constructor + DOMContentLoaded to connectedCallback + requestIdleCallback so the esm-wrapper chunks (~175 KiB) are fetched after paint instead of competing with critical resources. Falls back to setTimeout for Safari.