### PR TITLE
Replace constructor + DOMContentLoaded with connectedCallback in DocSearchContainer

### DIFF
--- a/apps/site/src/components/search/Search.astro
+++ b/apps/site/src/components/search/Search.astro
@@ -52,62 +52,59 @@ const onload = "this.media='all'; this.onload=null;"
   }
 
   class DocSearchContainer extends HTMLElement {
-    constructor() {
-      super()
-      window.addEventListener('DOMContentLoaded', async () => {
-        const { docsearch } = await import('@adrieldev/esm-wrapper')
+    async connectedCallback() {
+      const { docsearch } = await import('@adrieldev/esm-wrapper')
 
-        docsearch({
-          container: this,
-          appId: appId,
-          indexName: indexName,
-          apiKey: apiKey,
-          insights: false,
-          disableUserPersonalization: true,
-          placeholder: 'Search',
-          transformSearchClient: (searchClient) => {
-            const debouncedSearch = debounce(
-              (queries, resolve: (res: any) => void, reject: (err: any) => void) => {
-                searchClient.search(queries).then(resolve).catch(reject)
-              },
-              250
-            )
-            return {
-              ...searchClient,
-              search(queries) {
-                return new Promise((resolve, reject) => {
-                  debouncedSearch(queries, resolve, reject)
-                })
-              },
+      docsearch({
+        container: this,
+        appId: appId,
+        indexName: indexName,
+        apiKey: apiKey,
+        insights: false,
+        disableUserPersonalization: true,
+        placeholder: 'Search',
+        transformSearchClient: (searchClient) => {
+          const debouncedSearch = debounce(
+            (queries, resolve: (res: any) => void, reject: (err: any) => void) => {
+              searchClient.search(queries).then(resolve).catch(reject)
+            },
+            250
+          )
+          return {
+            ...searchClient,
+            search(queries) {
+              return new Promise((resolve, reject) => {
+                debouncedSearch(queries, resolve, reject)
+              })
+            },
+          }
+        },
+        transformItems: (items) => {
+          return items.map((item) => {
+            // Strip the ellipsis at the end. Add ellipsis via css instead.
+            const snippetValue = item._snippetResult?.content?.value
+            if (snippetValue) {
+              item._snippetResult.content.value = snippetValue.replace(
+                TRAILING_ELLIPSIS_PATTERN,
+                ''
+              )
             }
-          },
-          transformItems: (items) => {
-            return items.map((item) => {
-              // Strip the ellipsis at the end. Add ellipsis via css instead.
-              const snippetValue = item._snippetResult?.content?.value
-              if (snippetValue) {
-                item._snippetResult.content.value = snippetValue.replace(
-                  TRAILING_ELLIPSIS_PATTERN,
-                  ''
-                )
-              }
-              if (item._snippetResult.hierarchy) {
-                for (const value of Object.values(item._snippetResult.hierarchy)) {
-                  const hierarchyValue = value.value
-                  if (hierarchyValue && typeof hierarchyValue === 'string') {
-                    value.value = hierarchyValue.replace(TRAILING_ELLIPSIS_PATTERN, '')
-                  }
+            if (item._snippetResult.hierarchy) {
+              for (const value of Object.values(item._snippetResult.hierarchy)) {
+                const hierarchyValue = value.value
+                if (hierarchyValue && typeof hierarchyValue === 'string') {
+                  value.value = hierarchyValue.replace(TRAILING_ELLIPSIS_PATTERN, '')
                 }
               }
+            }
 
-              const url = new URL(item.url)
-              return {
-                ...item,
-                url: url.pathname + url.hash,
-              }
-            })
-          },
-        })
+            const url = new URL(item.url)
+            return {
+              ...item,
+              url: url.pathname + url.hash,
+            }
+          })
+        },
       })
     }
   }


### PR DESCRIPTION
## Summary

- Replaces `constructor` + `window.addEventListener('DOMContentLoaded', ...)` with `async connectedCallback`
- `connectedCallback` fires after the element is connected to the DOM, making the `DOMContentLoaded` workaround unnecessary
- Makes `DocSearchContainer` consistent with the other web components in the codebase (`V86Terminal`, `PhotoSwipeElement`)

## Test plan

- [ ] Open the site and confirm the DocSearch input renders and functions correctly
- [ ] Trigger a search to confirm results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)