### PR TITLE
Switch to JetBrains Mono variable font and tune typography weights

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@adrieldev/esm-wrapper": "workspace:*",
     "@docsearch/css": "4.6.3",
-    "@fontsource/jetbrains-mono": "5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@xterm/addon-fit": "0.11.0",
     "@xterm/xterm": "6.0.0",
     "fast-xml-builder": "1.2.0",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@adrieldev/esm-wrapper": "workspace:*",
     "@docsearch/css": "4.6.3",
-    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "5.2.8",
     "@xterm/addon-fit": "0.11.0",
     "@xterm/xterm": "6.0.0",
     "fast-xml-builder": "1.2.0",

--- a/apps/site/src/components/Head.astro
+++ b/apps/site/src/components/Head.astro
@@ -1,5 +1,5 @@
 ---
-import jetbrainsMonoLatin500Woff2 from '@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-normal.woff2?url'
+import jetbrainsMonoLatinVariableWoff2 from '@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2?url'
 
 import siteConfig from '@/libs/siteConfig'
 import { URLS } from '@/libs/UrlLibs.ts'
@@ -21,7 +21,7 @@ import { URLS } from '@/libs/UrlLibs.ts'
     rel="preload"
     as="font"
     type="font/woff2"
-    href={jetbrainsMonoLatin500Woff2}
+    href={jetbrainsMonoLatinVariableWoff2}
     crossorigin="anonymous"
   />
   <link

--- a/apps/site/src/components/Header.astro
+++ b/apps/site/src/components/Header.astro
@@ -14,7 +14,7 @@ import { URLS } from '@/libs/UrlLibs'
         <div class="mr-5">
           <Logo />
         </div>
-        <div class="hidden h-6 text-xl font-semibold xl:block">{siteConfig.title}</div>
+        <div class="hidden h-6 text-xl font-bold xl:block">{siteConfig.title}</div>
       </div>
     </Link>
   </div>

--- a/apps/site/src/components/PageTitle.astro
+++ b/apps/site/src/components/PageTitle.astro
@@ -10,7 +10,7 @@ const titleCasedTitle = titleCase(title)
 ---
 
 <h1
-  class="text-3xl leading-9 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14"
+  class="text-3xl leading-9 font-bold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14"
 >
   {titleCasedTitle}
 </h1>

--- a/apps/site/src/css/article-content.css
+++ b/apps/site/src/css/article-content.css
@@ -32,6 +32,20 @@ article {
       font-weight: 600;
     }
 
+    strong {
+      font-weight: 800;
+    }
+
+    /* Code block */
+    code {
+      font-weight: 500;
+    }
+
+    /* Inline code */
+    span[data-rehype-pretty-code-figure] code {
+      font-weight: 800;
+    }
+
     h1,
     h2,
     h3,

--- a/apps/site/src/css/global.css
+++ b/apps/site/src/css/global.css
@@ -4,7 +4,7 @@
 @plugin './toc-plugin.ts';
 
 @theme {
-  --font-mono: 'JetBrains Mono', monospace;
+  --font-mono: 'JetBrains Mono Variable', monospace;
   --color-primary-50: var(--color-blue-50);
   --color-primary-100: var(--color-blue-100);
   --color-primary-200: var(--color-blue-200);

--- a/apps/site/src/layouts/RootLayout.astro
+++ b/apps/site/src/layouts/RootLayout.astro
@@ -1,6 +1,6 @@
 ---
 import '@/css/global.css'
-import '@fontsource/jetbrains-mono/latin-500.css'
+import '@fontsource-variable/jetbrains-mono/wght.css'
 
 import Footer from '@/components/footer/Footer.astro'
 import Head from '@/components/Head.astro'
@@ -22,7 +22,7 @@ const { seoData } = Astro.props
     <SEO seoData={seoData} />
     <slot name="jsonLd" />
   </Head>
-  <body class="bg-white pl-[calc(100vw-100%)] font-mono text-black antialiased">
+  <body class="bg-white pl-[calc(100vw-100%)] font-mono font-medium text-black antialiased">
     <section class="mx-auto max-w-xl px-6 md:px-1 xl:max-w-4xl">
       <div class="flex h-screen flex-col justify-between">
         <Header />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
       '@docsearch/css':
         specifier: 4.6.3
         version: 4.6.3
-      '@fontsource/jetbrains-mono':
-        specifier: 5.2.8
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
         version: 5.2.8
       '@xterm/addon-fit':
         specifier: 0.11.0
@@ -936,8 +936,8 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@fontsource/jetbrains-mono@5.2.8':
-    resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -5903,7 +5903,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@fontsource/jetbrains-mono@5.2.8': {}
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@humanfs/core@0.19.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: 4.6.3
         version: 4.6.3
       '@fontsource-variable/jetbrains-mono':
-        specifier: ^5.2.8
+        specifier: 5.2.8
         version: 5.2.8
       '@xterm/addon-fit':
         specifier: 0.11.0


### PR DESCRIPTION
- Replace @fontsource/jetbrains-mono (single weight 500) with @fontsource-variable/jetbrains-mono (100–800 axis) so all weights render correctly instead of being synthesized by the browser
- Set body default to font-weight 500 (font-medium)
- Tune article prose: strong → 800, code blocks → 500, inline code → 800
- Reduce PageTitle from extrabold (800) to bold (700)
- Increase site header name from semibold (600) to bold (700)