### PR TITLE
Website spec fixes

### DIFF
--- a/apps/site/public/static/favicons/site.webmanifest
+++ b/apps/site/public/static/favicons/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "",
-  "short_name": "",
+  "name": "Adriel Martinez",
+  "short_name": "Adriel",
   "icons": [
     {
       "src": "/android-chrome-96x96.png",

--- a/apps/site/src/components/Head.astro
+++ b/apps/site/src/components/Head.astro
@@ -13,6 +13,7 @@ import { URLS } from '@/libs/UrlLibs.ts'
   <link rel="manifest" href="/static/favicons/site.webmanifest" />
   <link rel="mask-icon" href="/static/favicons/safari-pinned-tab.svg" color="#5bbad5" />
   <meta name="msapplication-TileColor" content="#000000" />
+  <meta name="color-scheme" content="light" />
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fff" />
   <meta name="generator" content={Astro.generator} />
   <link rel="sitemap" href="/sitemap-index.xml" />

--- a/apps/site/src/components/SEO.astro
+++ b/apps/site/src/components/SEO.astro
@@ -6,6 +6,7 @@ import siteConfig from '@/libs/siteConfig'
 type BasicData = {
   type: 'basic'
   title: string
+  noindex?: boolean
 }
 
 type FullData = {
@@ -36,7 +37,7 @@ const titleTemplate = `%s | ${siteConfig.title}`
 
 {
   seoData.type === 'basic' ? (
-    <Seo title={seoData.title} titleTemplate={titleTemplate} />
+    <Seo title={seoData.title} titleTemplate={titleTemplate} noindex={seoData.noindex} />
   ) : (
     <Seo
       title={seoData.title}

--- a/apps/site/src/css/article-content.css
+++ b/apps/site/src/css/article-content.css
@@ -215,8 +215,10 @@ article {
   .footnotes {
     @apply mt-12 border-t border-gray-200;
 
-    ol > li:target {
-      animation: highlight-footer 3s;
+    @media (prefers-reduced-motion: no-preference) {
+      ol > li:target {
+        animation: highlight-footer 3s;
+      }
     }
   }
 

--- a/apps/site/src/pages/404.astro
+++ b/apps/site/src/pages/404.astro
@@ -7,6 +7,7 @@ import { URLS } from '@/libs/UrlLibs'
 const seoData: SeoData = {
   type: 'basic',
   title: 'Not Found',
+  noindex: true,
 }
 ---
 


### PR DESCRIPTION
## Summary

- Add `noindex` to 404 page (was incorrectly marked `index, follow`)
- Fix empty `name`/`short_name` in web app manifest
- Declare `color-scheme: light` to prevent browser forced dark mode
- Guard footnote highlight animation with `prefers-reduced-motion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)