### PR TITLE
Add lazy loading to images

### DIFF
--- a/apps/site/src/components/ResponsivePicture.astro
+++ b/apps/site/src/components/ResponsivePicture.astro
@@ -32,6 +32,7 @@ const widths = potentialSizes.filter((size) => size <= maxWidth)
 props.widths = widths
 props.sizes = '(min-width: 1280px) 896px, 100vw'
 props.format = 'webp'
+props.loading = 'lazy'
 
 // set width and height for the fallback image
 const fallbackWidth = Math.max(...widths)


### PR DESCRIPTION
## Summary

- Set `loading="lazy"` on all `ResponsivePicture` images

Images only appear mid-article in prose, so there's no LCP image risk.
Explicit `width`/`height` are already set on the component, so no layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)