### PR TITLE
Fix CSP violation from inlined font data URIs

### DIFF
--- a/apps/site/astro.config.ts
+++ b/apps/site/astro.config.ts
@@ -89,6 +89,9 @@ export default defineConfig({
 
   vite: {
     plugins: [svgr(), tailwindcss()],
+    build: {
+      assetsInlineLimit: (filePath) => (filePath.includes('.woff') ? 0 : 4096),
+    },
   },
 
   markdown: {

--- a/apps/site/astro.config.ts
+++ b/apps/site/astro.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
   vite: {
     plugins: [svgr(), tailwindcss()],
     build: {
+      // Prevent font subsets from being inlined as data URIs, which would violate font-src 'self' CSP
       assetsInlineLimit: (filePath) => (filePath.includes('.woff') ? 0 : 4096),
     },
   },

--- a/apps/site/astro.config.ts
+++ b/apps/site/astro.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
     plugins: [svgr(), tailwindcss()],
     build: {
       // Prevent font subsets from being inlined as data URIs, which would violate font-src 'self' CSP
-      assetsInlineLimit: (filePath) => (filePath.includes('.woff') ? 0 : 4096),
+      assetsInlineLimit: (filePath) => (filePath.includes('.woff') ? false : undefined),
     },
   },
 


### PR DESCRIPTION
## Summary

- Configure Vite to never inline `.woff`/`.woff2` files as data URIs
- Prevents a `font-src 'self'` CSP violation caused by Vite inlining small font subsets (Greek, Cyrillic, etc.) below its 4KB asset threshold

The Latin subset that actually renders on screen is already preloaded separately, so there's no flash or performance impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)