### PR TITLE
Stop building sharp from source under pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,7 @@ packages:
 
 allowBuilds:
   esbuild: true
-  sharp: true
-
-ignoredBuiltDependencies:
-  - esbuild
-  - sharp
+  # sharp ships prebuilt binaries via its @img/sharp-* optional deps, so its
+  # install script must not run — letting it run makes node-gyp build from
+  # source and fail ("Please add node-addon-api"). Keep this false.
+  sharp: false


### PR DESCRIPTION
## Problem

`pnpm install` fails while building sharp from source:

```
sharp: Attempting to build from source via node-gyp
sharp: Please add node-addon-api to your dependencies
[ELIFECYCLE] Command failed with exit code 1.
```

## Root cause

pnpm 11 removed `onlyBuiltDependencies` / `ignoredBuiltDependencies` and replaced them with a single `allowBuilds` map. The "Update pnpm to v11" migration (#388) set `allowBuilds: { sharp: true }`, which runs sharp's `install/check.js`. That script falls back to a node-gyp source build, which fails because `node-addon-api` isn't a dependency. The old `ignoredBuiltDependencies: [sharp]` block meant to suppress this is dead config under pnpm 11.

sharp 0.34 ships prebuilt native binaries via its `@img/sharp-*` optional deps (covering darwin-arm64, linux-x64, etc. — all present in the lockfile) and needs no build step.

## Fix

- Set `allowBuilds: { sharp: false }` so sharp's install script never runs.
- Remove the now-dead `ignoredBuiltDependencies` block.

`require('sharp')` loads fine from the prebuilt binary (vips 8.17.3) and `pnpm install` completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)