### PR TITLE
Add prettier and eslint configs to turbo globalDependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,9 @@
     }
   },
   "globalDependencies": [
-    "pnpm-lock.yaml"
+    "pnpm-lock.yaml",
+    "prettier.config.js",
+    "eslint.config.js"
   ],
   "remoteCache": {
     "signature": true


### PR DESCRIPTION
## Summary

- Adds `prettier.config.js` and `eslint.config.js` to `globalDependencies` in `turbo.json`
- Ensures lint and format task caches are properly invalidated when either root-level config changes

## Test plan

- [ ] Confirm `turbo run lint` uses cache on a clean run
- [ ] Modify `prettier.config.js` or `eslint.config.js` and confirm cache is busted

🤖 Generated with [Claude Code](https://claude.com/claude-code)