### PR TITLE
Add pointer cursor to scroll-top button

### DIFF
--- a/apps/site/src/components/ScrollTop.astro
+++ b/apps/site/src/components/ScrollTop.astro
@@ -5,7 +5,7 @@ import ArrowUp from '@/assets/remix-icons/arrow-up-line.svg'
 <button
   id="scroll-top"
   aria-label="Scroll To Top"
-  class="fixed right-8 bottom-8 hidden rounded-full bg-gray-200 p-2 text-gray-500 transition-all hover:bg-gray-300"
+  class="fixed right-8 bottom-8 hidden cursor-pointer rounded-full bg-gray-200 p-2 text-gray-500 transition-all hover:bg-gray-300"
 >
   <ArrowUp class="size-6" />
 </button>


### PR DESCRIPTION
## Summary

Adds `cursor-pointer` to the scroll-to-top button. Native `<button>` elements render the default arrow cursor (unlike `<a>` links), so the pointer has to be added explicitly to signal the control is clickable.

## Testing

Verify in `pnpm dev` — hovering the floating scroll-top button (bottom-right, appears after scrolling) shows the pointer cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)