### PR TITLE
Remove placeholder author email from atom feed

### DIFF
--- a/apps/site/src/pages/atom.xml.ts
+++ b/apps/site/src/pages/atom.xml.ts
@@ -13,7 +13,6 @@ const copyrightNotice =
 
 const author = {
   name: siteConfig.author,
-  email: 'contact@websiteDomain',
 }
 
 export async function GET({ request }: { request: Request }) {


### PR DESCRIPTION
## What

The atom feed shipped `<email>contact@websiteDomain</email>` on the feed author **and every entry** — an unfilled placeholder that leaked into the one syndication surface subscribers consume.

## Why this fix

The `feed` library types `Author.email` as optional and its serializer only emits an `<email>` element when the field is present, so the clean fix is to drop the field entirely (no placeholder, no address published). The author *name* (`Adriel Martinez`) still renders.

## Verification

Built the site and confirmed `dist/atom.xml` contains zero `<email>` elements while `<name>Adriel Martinez</name>` is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)