### PR TITLE
Fix broken web app manifest icon path

### DIFF
--- a/apps/site/public/static/favicons/site.webmanifest
+++ b/apps/site/public/static/favicons/site.webmanifest
@@ -3,7 +3,7 @@
   "short_name": "Adriel",
   "icons": [
     {
-      "src": "/android-chrome-96x96.png",
+      "src": "/static/favicons/android-chrome-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     }


### PR DESCRIPTION
## What

`site.webmanifest` declared its icon as `/android-chrome-96x96.png`, but the file is served from `/static/favicons/android-chrome-96x96.png`. The referenced path 404s, so an installed PWA / "add to home screen" got a broken icon.

## Fix

Point the icon `src` at the actual asset location under `/static/favicons/`.

## Note (out of scope)

Only a single 96×96 icon exists. Full installability ideally also wants 192×192 and 512×512 icons, which would require generating new image assets — left as a follow-up.

## Verification

Confirmed the referenced path now matches the built asset at `dist/static/favicons/android-chrome-96x96.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)