### PR TITLE
Remove always-true guard in generate-summary

### DIFF
--- a/apps/site/src/libs/generate-summary.ts
+++ b/apps/site/src/libs/generate-summary.ts
@@ -39,10 +39,8 @@ const extractFirstSectionText = () => {
       }
     })
 
-    if (paragraphNodes) {
-      tree.type = 'root'
-      tree.children = paragraphNodes
-    }
+    tree.type = 'root'
+    tree.children = paragraphNodes
   }
 }
 


### PR DESCRIPTION
## What

In `extractFirstSectionText`, the summary builder wraps two assignments in `if (paragraphNodes) { ... }`. `paragraphNodes` is a locally declared array (`const paragraphNodes: Node[] = []`), so it is always truthy — the guard never gates anything.

## Fix

Remove the dead branch and run the assignments unconditionally. Behavior is identical.

## Verification

`pnpm check` and `pnpm test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)