### PR TITLE
Make theme-color consistent for the light-only site

### DIFF
--- a/apps/site/public/static/favicons/site.webmanifest
+++ b/apps/site/public/static/favicons/site.webmanifest
@@ -8,7 +8,7 @@
       "type": "image/png"
     }
   ],
-  "theme_color": "#000000",
-  "background_color": "#000000",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
   "display": "standalone"
 }

--- a/apps/site/src/components/Head.astro
+++ b/apps/site/src/components/Head.astro
@@ -14,7 +14,7 @@ import { URLS } from '@/libs/UrlLibs.ts'
   <link rel="mask-icon" href="/static/favicons/safari-pinned-tab.svg" color="#5bbad5" />
   <meta name="msapplication-TileColor" content="#000000" />
   <meta name="color-scheme" content="light" />
-  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fff" />
+  <meta name="theme-color" content="#fff" />
   <meta name="generator" content={Astro.generator} />
   <link rel="sitemap" href="/sitemap-index.xml" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## What

The site is light-only, but its browser/PWA chrome colors weren't consistent with that:

- The `theme-color` meta was qualified with `media="(prefers-color-scheme: light)"`, so it only applied when the visitor's OS was in light mode. A dark-OS visitor got **no** `theme-color`, so the browser painted its own (typically dark) chrome — address bar, pull-to-refresh, task switcher — around the always-white page.
- The manifest's `theme_color`/`background_color` were `#000000`, which would give an installed PWA a black title bar and a black→white splash flash.

## Fix

- Drop the `media` qualifier so `theme-color: #fff` applies unconditionally.
- Align the manifest `theme_color`/`background_color` to `#ffffff`.

The legacy `msapplication-TileColor` (`#000`, a rarely-used Windows tile hint) is left as-is.

## Verification

`pnpm check` passes; built `dist/static/favicons/site.webmanifest` shows the white colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)