### PR TITLE
Replace stale bun boilerplate in package READMEs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,15 +1,21 @@
 # cli
 
-To install dependencies:
+Interactive CLI (`@adrieldev/cli`) to scaffold and edit blog posts, built on
+`@inquirer/prompts`. Authored in TypeScript and built with `tsdown` into `dist/index.js`.
+
+From the repo root, `pnpm cli` builds it (`precli`) then runs
+`node packages/cli/dist/index.js` pointed at `apps/site/src/content/posts`. Use the
+"New Post" flow to scaffold a post — it names the folder `<YYYY-MM-DD>-<slug>` and writes
+valid frontmatter, so you don't hand-roll post directories.
+
+The `bin` entry needs a `#!/usr/bin/env node` shebang; it lives at the top of `src/index.ts`
+so tsdown preserves it (and grants the executable bit) in `dist/index.js`.
+
+## Commands
+
+Run from the repo root (pnpm workspace):
 
 ```bash
-bun install
+pnpm cli              # build (precli) then launch the post CLI
+pnpm --filter @adrieldev/cli build   # tsdown build only
 ```
-
-To run:
-
-```bash
-bun run index.ts
-```
-
-This project was created using `bun init` in bun v1.2.15. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/packages/eslint-configs/README.md
+++ b/packages/eslint-configs/README.md
@@ -1,15 +1,26 @@
 # eslint-configs
 
-To install dependencies:
+Shared flat ESLint config (`@adrieldev/eslint-configs`) consumed by every package in the
+workspace. Authored in TypeScript (`src/index.ts`) and built with `tsdown` into
+`dist/index.js` (+ `dist/index.d.ts`), consumed via the package `exports` map.
+
+The ESLint plugins it composes stay in `devDependencies`, and `tsdown.config.ts` sets
+`deps: { neverBundle: true }` to externalize them — tsdown only auto-externalizes
+`dependencies`/`peerDependencies`, so without this it would inline every plugin into a huge
+`index.js`. The plugins are deliberately not promoted to `dependencies`: this package is
+workspace-internal (never published, so its devDeps are always installed), and moving the
+plugins to prod deps drags their transitive tree into the production security scan and fails
+CI. `eslint` itself is a `peerDependency`.
+
+Because the config is consumed from `dist`, `turbo run lint`/`lint:fix` declare
+`@adrieldev/eslint-configs#build` as a dependency, so a fresh checkout must build it before
+linting works.
+
+## Commands
+
+Run from the repo root (pnpm workspace):
 
 ```bash
-bun install
+pnpm install          # install workspace deps
+pnpm --filter @adrieldev/eslint-configs build   # tsdown build
 ```
-
-To run:
-
-```bash
-bun run index.ts
-```
-
-This project was created using `bun init` in bun v1.2.13. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/packages/esm-wrapper/README.md
+++ b/packages/esm-wrapper/README.md
@@ -1,15 +1,23 @@
 # esm-wrapper
 
-To install dependencies:
+An ESM shim around `@docsearch/react` (`@adrieldev/esm-wrapper`) so Astro's SSR can consume it.
+Authored in TypeScript and built with `tsdown` into `dist/index.js`, consumed via the package
+`exports` map.
+
+`apps/site` imports this as `@adrieldev/esm-wrapper` and requires it to be built first —
+`pnpm dev` runs `predev` to build it once then runs it in watch mode (`tsdown --watch`)
+alongside `astro dev`, and `turbo run check` declares `@adrieldev/esm-wrapper#build` as a
+dependency. If site code shows missing-module errors, rebuild esm-wrapper.
+
+Don't edit `dist/` by hand or expect `apps/site` to pick up source changes automatically
+outside of `pnpm dev` — the site consumes the built `dist/index.js`.
+
+## Commands
+
+Run from the repo root (pnpm workspace):
 
 ```bash
-bun install
+pnpm install          # install workspace deps
+pnpm --filter @adrieldev/esm-wrapper build   # tsdown build
+pnpm --filter @adrieldev/esm-wrapper dev     # tsdown --watch
 ```
-
-To run:
-
-```bash
-bun run index.ts
-```
-
-This project was created using `bun init` in bun v1.2.13. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.


### PR DESCRIPTION
The eslint-configs, esm-wrapper, and cli READMEs were identical `bun init` templates referencing bun, which the repo does not use. Rewrite each to describe the package accurately with correct pnpm/tsdown commands.