### PR TITLE
Add lastmod to sitemap entries

### DIFF
--- a/apps/site/astro.config.ts
+++ b/apps/site/astro.config.ts
@@ -22,6 +22,7 @@ import informationIcon from './src/assets/remix-icons/information-line.svg?raw'
 import lightbulbIcon from './src/assets/remix-icons/lightbulb-line.svg?raw'
 import spamIcon from './src/assets/remix-icons/spam-line.svg?raw'
 import generateHeaders from './src/plugins/integration-generate-headers'
+import { getPostDates } from './src/plugins/post-dates'
 import rehypeHideHeading from './src/plugins/rehype-hide-heading'
 import rehypeStripHiddenMarker from './src/plugins/rehype-strip-hidden-marker'
 import remarkIncludeCode from './src/plugins/remark-include-code'
@@ -72,6 +73,9 @@ const config = {
     },
   ],
 }
+
+// Read once at config load rather than per-entry inside serialize()
+const postDates = await getPostDates()
 
 const headerIcon = fromHtmlIsomorphic(
   `<span class="content-header-link-placeholder">${addDimensionsToSvg(hashTagIcon, 24)}</span>`,
@@ -146,7 +150,13 @@ export default defineConfig({
     generateHeaders(),
     react(),
     mdx(),
-    sitemap(),
+    sitemap({
+      serialize: (item) => {
+        const id = new URL(item.url).pathname.match(/^\/posts\/(.+)$/)?.[1]
+        const date = id ? postDates.get(id) : undefined
+        return date ? { ...item, lastmod: date.toISOString() } : item
+      },
+    }),
     robotsTxt(),
     compress({
       Image: false,

--- a/apps/site/src/plugins/integration-generate-headers.ts
+++ b/apps/site/src/plugins/integration-generate-headers.ts
@@ -1,23 +1,9 @@
-import { readdir, readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { writeFile } from 'node:fs/promises'
 
 import type { AstroIntegration } from 'astro'
-import matter from 'gray-matter'
 
 import { truncateToSeconds } from '../libs/DateUtils'
-
-async function getLatestPostDate(postsDir: string): Promise<Date> {
-  const entries = await readdir(postsDir, { withFileTypes: true })
-  let latest = new Date(0)
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue
-    const src = await readFile(join(postsDir, entry.name, 'index.mdx'), 'utf-8')
-    const { data } = matter(src)
-    const date: Date = data.updatedAt ?? data.createdAt
-    if (date > latest) latest = date
-  }
-  return latest
-}
+import { getLatestPostDate } from './post-dates'
 
 function serializeHeaders(rules: Map<string, string[]>): string {
   return [...rules.entries()]
@@ -31,8 +17,7 @@ export default function generateHeaders(): AstroIntegration {
     name: 'generate-headers',
     hooks: {
       'astro:build:done': async ({ dir }) => {
-        const postsDir = new URL('../content/posts', import.meta.url).pathname
-        const lastModified = truncateToSeconds(await getLatestPostDate(postsDir)).toUTCString()
+        const lastModified = truncateToSeconds(await getLatestPostDate()).toUTCString()
 
         const rules = new Map<string, string[]>([
           [

--- a/apps/site/src/plugins/post-dates.ts
+++ b/apps/site/src/plugins/post-dates.ts
@@ -1,0 +1,36 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import matter from 'gray-matter'
+
+const postsDir = new URL('../content/posts', import.meta.url).pathname
+
+/**
+ * Reads `updatedAt ?? createdAt` for every post straight from the filesystem,
+ * keyed by post id (the `<YYYY-MM-DD>-<slug>` folder name, which is also the
+ * route segment under `/posts/`).
+ *
+ * Build-time consumers here are integrations and integration options, which run
+ * outside the module graph and so cannot import `astro:content`.
+ */
+export async function getPostDates(): Promise<Map<string, Date>> {
+  const entries = await readdir(postsDir, { withFileTypes: true })
+  const dates = new Map<string, Date>()
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const src = await readFile(join(postsDir, entry.name, 'index.mdx'), 'utf-8')
+    const { data } = matter(src)
+    dates.set(entry.name, data.updatedAt ?? data.createdAt)
+  }
+
+  return dates
+}
+
+export async function getLatestPostDate(): Promise<Date> {
+  let latest = new Date(0)
+  for (const date of (await getPostDates()).values()) {
+    if (date > latest) latest = date
+  }
+  return latest
+}


### PR DESCRIPTION
Sitemap entries were bare <loc> with no dates, so crawlers had no signal
about which posts changed. Post URLs now carry a <lastmod> derived from
`updatedAt ?? createdAt` — the same rule the atom feed's Last-Modified
uses. Non-post pages are left without one rather than given a fabricated
date.

`astro.config.ts` cannot import `astro:content`, so the dates are read
from frontmatter on disk. That globbing already existed inside
integration-generate-headers.ts; it moves to a shared post-dates.ts that
both consumers use instead of being duplicated.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>