### PR TITLE
fix(site): allow any host in Vite dev server

### DIFF
--- a/apps/site/astro.config.ts
+++ b/apps/site/astro.config.ts
@@ -106,6 +106,10 @@ export default defineConfig({
 
   vite: {
     plugins: [tailwindcss()],
+    server: {
+      // Coder's preview subdomain host is per-workspace; skip Vite's host check.
+      allowedHosts: true,
+    },
     build: {
       // Vite 8's esbuild CSS minifier strips Tailwind v4's responsive @media
       // rules from the build (dev is unaffected), dropping every sm:/md:/lg:/xl:


### PR DESCRIPTION
Coder's preview subdomain host is per-workspace and random, so Vite's host verification blocks the dev server. Disable the check via server.allowedHosts for the dev server only.